### PR TITLE
Add simple web interface for Ollama

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,11 +2,20 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Hello World App</title>
+  <title>Ollama Deepseek Demo</title>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <div id="app"></div>
+  <div id="ollama-app">
+    <h2>Ask Deepseek</h2>
+    <form id="ollama-form">
+      <textarea id="ollama-prompt" rows="4" cols="50" placeholder="Enter prompt"></textarea><br>
+      <button type="submit">Send</button>
+    </form>
+    <pre id="ollama-response"></pre>
+  </div>
   <script type="module" src="main.js"></script>
+  <script type="module" src="ollama-ui.js"></script>
 </body>
 </html>

--- a/src/ollama-ui.js
+++ b/src/ollama-ui.js
@@ -1,0 +1,42 @@
+const API_URL = 'http://localhost:11434/api/generate';
+const MODEL_NAME = 'deepseek-r1:1.5b';
+
+export async function generate(prompt) {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: MODEL_NAME,
+      prompt,
+      stream: false
+    })
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`);
+  }
+
+  const data = await res.json();
+  return data.response;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('ollama-form');
+  const input = document.getElementById('ollama-prompt');
+  const output = document.getElementById('ollama-response');
+
+  if (!form) return;
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    output.textContent = 'Loading...';
+    try {
+      const text = await generate(input.value);
+      output.textContent = text;
+    } catch (err) {
+      output.textContent = 'Error: ' + err.message;
+    }
+  });
+});

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,3 +5,7 @@ body {
   margin-top: 20px;
   font-size: 2em;
 }
+
+#ollama-app {
+  margin-top: 40px;
+}


### PR DESCRIPTION
## Summary
- create `src/ollama-ui.js` with a helper to call the local Ollama API using the Deepseek model
- add new HTML form in `src/index.html` for sending prompts
- add basic styling for the new interface

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68527310bbd88322905155a618f8c898